### PR TITLE
logback 설정, mybatis 연동, 프로필 별 구동 환경, 프로젝트 구조 구성

### DIFF
--- a/src/main/resources/logging/logback-file-appender.xml
+++ b/src/main/resources/logging/logback-file-appender.xml
@@ -1,10 +1,11 @@
 <included>
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <File>${logs}/logback.log</File>
+        <File>logs/logback.log</File>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %highlight(%-5level) %cyan(%logger{36}) - %msg%n</pattern>
         </encoder>
         <rollingPolicy class = "ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logs/logback.%d{yyyy-MM-dd-HH-mm}.log</fileNamePattern>
             <maxFileSize>20MB</maxFileSize>
             <maxHistory>30</maxHistory>
             <totalSizeCap>1000MB</totalSizeCap>>

--- a/src/main/resources/logging/logback-local.xml
+++ b/src/main/resources/logging/logback-local.xml
@@ -1,6 +1,5 @@
 <included>
     <include resource="logging/logback-console-appender.xml/"/>
-<!--        <logger name="com.marketGola"/>-->
         <logger name="com.marketGola" level="DEBUG"/>
     <root level="INFO">
         <appender-ref ref="STDOUT"/>

--- a/src/main/resources/logging/logback-prod.xml
+++ b/src/main/resources/logging/logback-prod.xml
@@ -1,7 +1,8 @@
 <included>
     <include resource="logging/logback-console-appender.xml/"/>
-        <logger name="com.marketGola" level="INFO"/>
-    <root level="info">
+    <include resource="logging/logback-file-appender.xml/"/>
+    <logger name="com.marketGola" level="INFO"/>
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
 </included>


### PR DESCRIPTION
### **개요**

*Exception은 별도로 올리겠습니다. 

**- logback 설정** 
logback-file-appender.xml
-운영 환경에서는 파일로 로그를 남겼습니다.
-최상위 위치에 logs 폴더를 만들어 logback_log 이름으로 로그가 쌓이도록 했습니다.

logback-dev/local/prod.xml
-dev, local, prod 환경 별로 logback.xml 설정을 나눴습니다

logback-console-appender.xml
-중복을 줄이기 위해 환경 별로 겹치는 console-appender.xml을 별도로 분리했습니다. 

**- mybatis 연동**
현재 프로젝트 구조에서는 아래 코드로 mapper 위치를 명시해야 테스트 코드에서 mapper 를 읽어올 수 있습니다. 그래서 아래 설정을 포함했습니다.  mybatis.mapper-locations=classpath:/mapper/**/*.xml

**프로필 별 구동 환경**
application.properties 에서 dev, local, prod 를 선택하도록 구성했습니다. 

**프로젝트 구조 구성**
- 도메인 별 모듈 구조로 구성하였습니다. 

### **이슈 링크**

#2  #3  #4 

### **작업 사항 (변경 사항)**

### 테스트 내역 (o/x)

**Mybatis 연동** 
mysql 에 로컬 개발 용 marketgola 와 JUnit 테스트용 marketgola_testcase 를 만들었습니다. 
Mapper.xml 에 작성된 쿼리대로 db 인서트가 잘 되고 있습니다. 

- [Get] http://localhost:8080/user/4 에서 marketgola db의 회원을 id 별로 조회를 잘 해오는 것을 확인했습니다. 
- [POST] http://localhost:8080/user/save 에서 marketgola db에 회원 등록이 잘 되는 것을 확인했습니다. 

**logback 설정**
- 현재 application.properties 는 local 환경만 세팅해두었습니다. local 환경에서 logback 설정 지정한 대로 동작하는 것을 확인했습니다.  (prod, dev에 어떤 환경을 설정해야할지 확실하지 않아서요) 아래 prod 환경 테스트 시에는 임시로 application-prod.properties를 local 과 동일하게 적용해보았습니다. 

*테스트 통과 x 
-지정한 logs 폴더에 logback.log 파일은 생기지만, 로그가 적재되지 않습니다. 
-파일명에 날짜를 지정했지만(logs/logback-%d{yyyy-MM-dd-HH-mm}.%i.log) 날짜 형태로 저장되지 않습니다. 

### **리뷰 받고 싶은 내용**
(1) 위의 테스트 통과 되지 못한 사항에 대해서 어떤 접근을 할 수 있을지 조언 부탁드립니다. 
현재 logback-file-appender.xml 파일을 공식문서 (https://logback.qos.ch/manual/appenders.html) 참고하여 작성하였는데, 
어떻게 풀어볼지 실마리를 못찾았습니다. prod 환경에는 local 과 다른 설정이 필요한 걸까요? 

(2) 현재 Commit 메시지에서 개선할 사항이 있다면, 피드백 받고 싶습니다. 
초반에는 깃 규칙을 따로 생각하고 있지 않아서 파일 단위 커밋이 많은데, 후반부에는 가급적 이슈와 관련된 파일은 한번에 커밋하려고 했습니다. 

