### PR TITLE
jacoco 적용

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: 'CI'
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'develop'
+  pull_request:
+    branches:
+      - 'main'
+      - 'develop'
+
+jobs:
+  checkout:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+
+      - name: Upload Jacoco Report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: jacoco-report
+          path: build/reports/jacoco/test/html

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.7.0'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
+	id 'jacoco'
 }
 
 group = 'com.flab'
@@ -33,6 +34,35 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
-tasks.named('test') {
+test {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacoco {
+	toolVersion = "0.8.8"
+}
+
+jacocoTestReport {
+	finalizedBy jacocoTestCoverageVerification
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			element = 'CLASS' //각각의 클래스 파일이 이 기준을 넘어야 함
+
+			limit {
+				counter = 'INSTRUCTION'
+				value = 'COVEREDRATIO'
+				minimum = 0.60
+			}
+
+			limit {
+				counter = 'BRANCH'
+				value = 'COVEREDRATIO'
+				minimum = 0.60
+			}
+		}
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,25 +44,42 @@ jacoco {
 }
 
 jacocoTestReport {
-	finalizedBy jacocoTestCoverageVerification
+    finalizedBy jacocoTestCoverageVerification
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    'com/flab/marketgola/*/mapper/*',
+                    'com/flab/marketgola/*/dto/*',
+                    'com/flab/marketgola/*/exception/*',
+                    'com/flab/marketgola/MarketGolaApplication.class'
+            ])
+        }))
+    }
 }
 
 jacocoTestCoverageVerification {
-	violationRules {
-		rule {
-			element = 'CLASS' //각각의 클래스 파일이 이 기준을 넘어야 함
+    violationRules {
+        rule {
+            element = 'CLASS' //각각의 클래스 파일이 이 기준을 넘어야 함
 
-			limit {
-				counter = 'INSTRUCTION'
-				value = 'COVEREDRATIO'
-				minimum = 0.60
-			}
+            limit {
+                counter = 'INSTRUCTION'
+                value = 'COVEREDRATIO'
+                minimum = 0.60
+            }
 
-			limit {
-				counter = 'BRANCH'
-				value = 'COVEREDRATIO'
-				minimum = 0.60
-			}
-		}
-	}
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.60
+            }
+
+            excludes = [
+                    '*.exception.*',
+                    '*.mapper.*',
+                    '*.dto.*',
+                    'com.flab.marketgola.MarketGolaApplication'
+            ]
+        }
+    }
 }

--- a/src/main/java/com/flab/marketgola/lombok.config
+++ b/src/main/java/com/flab/marketgola/lombok.config
@@ -1,0 +1,2 @@
+# 모든 롬복으로 생성된 메소드에 @Generated 어노테이션 추가, Jacoco가 무시함
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
### **개요**
테스트를 충분히 작성했는지 확인하기 위해 jacoco를 적용하였습니다.


### **이슈 링크**

#16 

### **작업 사항 (변경 사항)**

### 테스트 내역 (o/x)
jacoco로 테스트 리포트가 html 파일로 생성되는 것을 확인했습니다.
60% 이상의 커버리지가 충족되지 않을시 build가 되지 않는 것을 확인했습니다.
lombok으로 생성된 코드는 리포트에 포함되지 않는 것을 확인했습니다.

### **리뷰 받고 싶은 내용**
일단은 어느 정도의 기준이 적절한지 몰라서 instruction과 branch 커버리지의 최소 기준을 60%로 잡았습니다. 그런데 생성자도 테스트를 해야할까요? 생성자 테스트 하지 않은 것도 coverage에 포함되더라구요

### CI 관련 추가 내용
다음 기능을 구현하였습니다.

1. develop 또는 main branch로 push가 되거나 pull request가 요청될 때 Workflow를 실행한다.
2. ubuntu 최신 stable 버전과 JDK는 Eclipse Temurin 11을 이용한다.
3. Gradle을 이용해 빌드하고 CI 속도를 높히기 위하여 의존하는 라이브러리들을 캐싱한다.
4. html Jacoco Report를 업로드한다.
5. 테스트가 실패하거나 Jacoco의 최소 커버리지를 충족하지 못하여 빌드가 실패하는 경우 push 또는 pull request한 사람의 이메일로 알림을 준다. (이 기능은 이미 github이 제공하고 있어서 따로 만질 부분은 없었습니다. )