### PR TITLE
[#39] 주문하기 기능 무한 루프 문제

### DIFF
--- a/src/main/java/com/flab/marketgola/order/service/OrderService.java
+++ b/src/main/java/com/flab/marketgola/order/service/OrderService.java
@@ -10,6 +10,7 @@ import com.flab.marketgola.order.mapper.OrderProductMapper;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
@@ -20,7 +21,7 @@ public class OrderService {
     private final OrderProductMapper orderProductRepository;
     private final StockSubtractionStrategy stockSubtractionStrategy;
 
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public long createOrder(long userId, CreateOrderRequestDto request) {
         Order order = request.toOrder(userId);
         List<OrderProduct> orderProducts = request.toOrderProducts();

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -102,7 +102,7 @@ CREATE TABLE `order`
     `receiver_address` varchar(100)                                            NOT NULL,
     `order_status`     enum ('PROCESSING','DELIVERING','DELIVERED','CANCELED') NOT NULL DEFAULT 'PROCESSING',
     `created_at`       datetime                                                NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `updated_at`       datetime                                                NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `updated_at`       datetime(6)                                             NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     `delivered_at`     datetime                                                         DEFAULT NULL,
     `user_id`          int unsigned                                            NOT NULL,
     PRIMARY KEY (`id`),


### PR DESCRIPTION
### **개요**
주문하기 기능 안에 재고 감소 로직 관련하여 여러명이 동시에 재고를 감소할 때 무한 루프가 도는 문제가 있었습니다.
하나의 트랜잭션 안에서 낙관적 락이 업데이트 실패 후 재시도를  하기 때문에 발생한 문제로, 주문하기 메소드의 Isolation Level을 READ COMMITTED로 바꾸어 해결하였습니다.


### **이슈 링크**

#39

### **작업 사항 (변경 사항)**

1. OrderService.createOrder() 의 Transaction Isolation Level을 READ COMMITTED로 변경
2. Schema.sql의 Product 테이블의 updated_at의 데이터 타입을 DATETIME에서 DATETIME(6)으로 변경 후 이에 맞게 Default Value 도 변경

### 테스트 내역 (o/x)
1. OrderServiceTest의 모든 테스트가 정상 작동하는 것을 확인했습니다.
